### PR TITLE
Switch to HarvestMigrateSourceList

### DIFF
--- a/dkan_harvest_dcatap.migrate.inc
+++ b/dkan_harvest_dcatap.migrate.inc
@@ -26,7 +26,7 @@ class HarvestMigrationDCATAP extends HarvestMigration {
     $this->itemUrl = drupal_realpath($this->dkanHarvestSource->getCacheDir()) .
             '/:id';
 
-    $this->source = new MigrateSourceList(
+    $this->source = new HarvestMigrateSourceList(
             new HarvestList($this->dkanHarvestSource->getCacheDir()),
             new MigrateItemJSON($this->itemUrl),
             $this->getCkanDatasetFields(),


### PR DESCRIPTION
DKAN Harvest changed to use the HarvestMigrateSourceList class to be able to provide support for the `--limit` option in drush commands. This PR updates `dkan_harvest_ckan` to accommodate the upstream change.